### PR TITLE
Fixes #4 : Add tool to get BTC balance

### DIFF
--- a/src/app/api/ai-plugin/route.ts
+++ b/src/app/api/ai-plugin/route.ts
@@ -102,6 +102,68 @@ export async function GET() {
           },
         },
       },
+      // DONE
+      "/api/tools/get-btc-balance": {
+        get: {
+          operationId: "get-btc-balance",
+          summary: "Get BTC balance",
+          description: "Respond with BTC address and balance",
+          responses: {
+            "200": {
+              description: "Successful response",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      btcBalance: {
+                        type: "string",
+                        description: "The current BTC balance of the user",
+                      },
+                      btcAddress: {
+                        type: "string",
+                        description: "The user's BTC address",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Bad request",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: {
+                        type: "string",
+                        description: "Error message",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "500": {
+              description: "Error response",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: {
+                        type: "string",
+                        description: "Error message",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
   };
 

--- a/src/app/api/tools/get-btc-balance/route.ts
+++ b/src/app/api/tools/get-btc-balance/route.ts
@@ -1,0 +1,58 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import {
+  Bitcoin as SignetBTC,
+  BTCRpcAdapters,
+  utils,
+  // RSVSignature,
+  // MPCSignature,
+  // BTCUnsignedTransaction,
+} from "signet.js";
+
+const CONTRACT = new utils.chains.near.contract.NearChainSignatureContract({
+  networkId: "mainnet",
+  contractId: "v1.signer",
+});
+
+const btcRpcAdapter = new BTCRpcAdapters.Mempool("https://mempool.space/api");
+
+const Bitcoin = new SignetBTC({
+  network: "mainnet",
+  contract: CONTRACT,
+  btcRpcAdapter,
+});
+
+export async function GET() {
+  const mbMetadataHeader = (await headers()).get("mb-metadata");
+  const mbMetadata: { accountId: string } =
+    mbMetadataHeader && JSON.parse(mbMetadataHeader);
+
+  const { accountId } = mbMetadata || {};
+  console.log("accountId", accountId);
+
+  // const { searchParams } = new URL(request.url);
+  // const accountId = searchParams.get("accountId");
+
+  const { address } = await Bitcoin.deriveAddressAndPublicKey(
+    accountId as string,
+    // "0xmht.near",
+    "bitcoin-1"
+  );
+
+  const btcAddress = address;
+
+  const btcBalance = await Bitcoin.getBalance(btcAddress);
+
+  // if (!accountId) {
+  //   return NextResponse.json(
+  //     {
+  //       error: "Unable to find user data in the request",
+  //     },
+  //     {
+  //       status: 500,
+  //     }
+  //   );
+  // }
+
+  return NextResponse.json({ btcBalance, btcAddress });
+}


### PR DESCRIPTION
### Summary

This PR updates the plugin manifest `/api/ai-plugin` to include the following tool:

- `get-btc-balance`

This tool should allow fetching the BTC balance for a user's wallet address.

### Changes

- [x]  Add the tool to the plugin manifest.

- [x]  Ensure the tool includes the appropriate schema definitions and operation details.

- [x]  Verify the updated manifest is still accessible at `/api/ai-plugin`.

### Related Issue
Fixes #4