### PR TITLE
Fixes #6 : Add tool to send BTC transaction

### DIFF
--- a/src/app/api/ai-plugin/route.ts
+++ b/src/app/api/ai-plugin/route.ts
@@ -164,6 +164,95 @@ export async function GET() {
           },
         },
       },
+      // DONE
+      "/api/tools/send-btc-txn": {
+        get: {
+          operationId: "send-btc-txn",
+          summary: "Relay/Send the signed BTC mainnet transaction",
+          description:
+            "Send signed transaction to BTC mainnet. The signature is received form the txHash of the signed NEAR transaction. Other parameters are the BTC receiver address, BTC amount in satoshi.",
+          parameters: [
+            {
+              name: "btcReceiver",
+              in: "query",
+              required: true,
+              schema: {
+                type: "string",
+              },
+              description: "The BTC address of the receiver",
+            },
+            {
+              name: "btcAmountInSatoshi",
+              in: "query",
+              required: true,
+              schema: {
+                type: "string",
+              },
+              description: "The amount of BTC to transfer in satoshi",
+            },
+            {
+              name: "txHash",
+              in: "query",
+              required: true,
+              schema: {
+                type: "string",
+              },
+              description: "The txHash of the signed txn from near",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Successful response",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      txHash: {
+                        type: "string",
+                        description:
+                          "The txHash of the txn relayed to BTC chain :",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Bad request",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: {
+                        type: "string",
+                        description: "Error message",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "500": {
+              description: "Server error",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: {
+                        type: "string",
+                        description: "Error message",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
   };
 

--- a/src/app/api/tools/send-btc-txn/route.ts
+++ b/src/app/api/tools/send-btc-txn/route.ts
@@ -1,0 +1,155 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import {
+  Bitcoin as SignetBTC,
+  BTCRpcAdapters,
+  utils,
+  RSVSignature,
+  MPCSignature,
+} from "signet.js";
+import { providers, connect } from "near-api-js";
+import { toRSV } from "signet.js/src/chains/utils";
+import {
+  ExecutionOutcomeWithId,
+  FinalExecutionOutcome,
+} from "near-api-js/lib/providers";
+
+const CONTRACT = new utils.chains.near.contract.NearChainSignatureContract({
+  networkId: "mainnet",
+  contractId: "v1.signer",
+});
+
+const btcRpcAdapter = new BTCRpcAdapters.Mempool("https://mempool.space/api");
+
+const Bitcoin = new SignetBTC({
+  network: "mainnet",
+  contract: CONTRACT,
+  btcRpcAdapter,
+});
+
+export async function GET(request: Request) {
+  try {
+    const mbMetadataHeader = (await headers()).get("mb-metadata");
+    const mbMetadata: { accountId: string } =
+      mbMetadataHeader && JSON.parse(mbMetadataHeader);
+    const { accountId } = mbMetadata || {};
+
+    const { searchParams } = new URL(request.url);
+    const btcReceiverAddress = searchParams.get("btcReceiver");
+    const btcAmountInSatoshi = searchParams.get("btcAmountInSatoshi");
+    const txHash = searchParams.get("txHash");
+
+    console.log("btcReceiverAddress", btcReceiverAddress);
+    console.log("btcAmountInSatoshi", btcAmountInSatoshi);
+    console.log("txHash", txHash);
+
+    if (!btcReceiverAddress || !btcAmountInSatoshi || !txHash) {
+      console.log(
+        `btcReceiver: ${btcReceiverAddress}\nbtcAmountInSatoshi: ${btcAmountInSatoshi}\ntxHash: ${txHash}`
+      );
+
+      return NextResponse.json(
+        {
+          error:
+            '"btcReceiver", "btcAmountInSatoshi" and "txHash" are required parameters',
+        },
+        { status: 400 }
+      );
+    }
+
+    // Get the signature from the txHash and send it to BTC mainnet
+    const connectionConfig = {
+      networkId: "mainnet",
+      nodeUrl: "https://rpc.mainnet.near.org",
+    };
+    const near = await connect(connectionConfig);
+    const txFinalOutcome = await near.connection.provider.txStatus(
+      txHash,
+      accountId,
+      "FINAL"
+    );
+
+    // get SuccessValue from receipts_outcome and convert base64 to string
+    const decodedSuccessValue = getDecodedSuccessValue(
+      txFinalOutcome.receipts_outcome
+    );
+    const mpcSignature: MPCSignature = JSON.parse(
+      decodedSuccessValue as string
+    );
+
+    console.log("mpcSignature", mpcSignature);
+
+    const mpcSignatures: RSVSignature[] = [toRSV(mpcSignature)];
+
+    console.log("mpcSignatures", mpcSignatures);
+
+    // get sender btc address
+    const { address: btcSenderAddress, publicKey: btcSenderPublicKey } =
+      await Bitcoin.deriveAddressAndPublicKey(accountId as string, "bitcoin-1");
+
+    const { transaction } = await Bitcoin.getMPCPayloadAndTransaction({
+      publicKey: btcSenderPublicKey,
+      from: btcSenderAddress,
+      to: btcReceiverAddress,
+      value: btcAmountInSatoshi.toString(),
+    });
+
+    // console.log("transaction", transaction);
+
+    // set maximum fee rate
+    // transaction.psbt.setMaximumFeeRate(10000);
+
+    const signedTransaction = Bitcoin.addSignature({
+      transaction,
+      mpcSignatures,
+    });
+
+    const btcTxnHash = await Bitcoin.broadcastTx(signedTransaction);
+
+    return NextResponse.json({ txHash: btcTxnHash }, { status: 200 });
+  } catch (error) {
+    console.error("Error generating EVM transaction:", error);
+    return NextResponse.json(
+      { error: "Failed to generate EVM transaction" },
+      { status: 500 }
+    );
+  }
+}
+
+const getDecodedSuccessValue = (receiptsOutcome: ExecutionOutcomeWithId[]) => {
+  let successReceiptId: string | null = null;
+  let successValue = null;
+
+  // Find the SuccessReceiptId
+  receiptsOutcome.forEach((receipt) => {
+    //@ts-ignore
+    if (receipt.outcome.status.SuccessReceiptId) {
+      //@ts-ignore
+      successReceiptId = receipt.outcome.status.SuccessReceiptId;
+    }
+  });
+
+  if (!successReceiptId) return null; // Return null if no SuccessReceiptId is found
+
+  // Find the SuccessValue corresponding to the SuccessReceiptId
+  receiptsOutcome.forEach((receipt) => {
+    if (
+      receipt.id === successReceiptId &&
+      //@ts-ignore
+      receipt.outcome.status.SuccessValue !== undefined
+    ) {
+      //@ts-ignore
+      successValue = receipt.outcome.status.SuccessValue;
+    }
+  });
+
+  if (!successValue) return null; // Return null if no SuccessValue is found
+
+  // Decode from Base64 to String
+  try {
+    return atob(successValue); // Decode Base64
+  } catch (error) {
+    console.error("Error decoding Base64:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
### Description

This PR updates the plugin manifest /api/ai-plugin to include the following tool:

- send-btc-txn

This tool should broadcast a signed BTC transaction to the Bitcoin mainnet.

### Changes

- [x]  Add the tool to the plugin manifest.

- [x]  Ensure the tool includes the appropriate schema definitions and operation details.

- [x]  Verify the updated manifest is still accessible at /api/ai-plugin.

### Related Issue

Fixes #6