### PR TITLE
Fixes #70 : Convert MPC signature to RSV signature in send-btc-txn tool

### DIFF
--- a/src/app/api/tools/send-btc-txn/route.ts
+++ b/src/app/api/tools/send-btc-txn/route.ts
@@ -10,6 +10,7 @@ import {
   chainAdapters,
   RSVSignature,
   MPCSignature,
+  utils,
   // fix: convert toRSV function
 } from "signet.js";
 
@@ -79,21 +80,23 @@ export async function GET(request: Request) {
     const mpcSignature: MPCSignature = JSON.parse(
       decodedSuccessValue as string
     );
-    //fix: convert MPC signature to RSV signature
-    // const rsvSignatures: RSVSignature[] = [toRSV(mpcSignature)];
-    const rsvSignatures: RSVSignature[] = [];
+
+    const rsvSignatures: RSVSignature[] = [
+      utils.cryptography.toRSV(mpcSignature),
+    ];
 
     // get sender btc address
     const { address: btcSenderAddress, publicKey: btcSenderPublicKey } =
       await bitcoin.deriveAddressAndPublicKey(accountId as string, "bitcoin-1");
 
     // create MPC payload and txn
-    const { transaction } = await bitcoin.prepareTransactionForSigning({
-      publicKey: btcSenderPublicKey,
-      from: btcSenderAddress,
-      to: btcReceiverAddress,
-      value: btcAmountInSatoshi.toString(),
-    });
+    const { transaction, hashesToSign } =
+      await bitcoin.prepareTransactionForSigning({
+        publicKey: btcSenderPublicKey,
+        from: btcSenderAddress,
+        to: btcReceiverAddress,
+        value: btcAmountInSatoshi.toString(),
+      });
 
     const signedTransaction = bitcoin.finalizeTransactionSigning({
       transaction,


### PR DESCRIPTION
### Summary

Fixes the send-btc-txn tool to convert MPC signature to RSV format before broadcasting.

### Changes made

- [x] Convert MPC signature to RSV format.

- [x] Verify that the transaction is broadcast successfully using the RSV signature format.

## Related Issue
Fixes #70 