### PR TITLE
Fixes #42 : Fix Bitcoin mainnet gas settings

### DIFF
--- a/src/app/api/tools/send-btc-txn/route.ts
+++ b/src/app/api/tools/send-btc-txn/route.ts
@@ -11,7 +11,6 @@ import {
   RSVSignature,
   MPCSignature,
   utils,
-  // fix: convert toRSV function
 } from "signet.js";
 
 const CONTRACT = new contracts.near.ChainSignatureContract({
@@ -41,10 +40,6 @@ export async function GET(request: Request) {
     const btcReceiverAddress = searchParams.get("btcReceiver");
     const btcAmountInSatoshi = searchParams.get("btcAmountInSatoshi");
     const txHash = searchParams.get("txHash");
-
-    console.log("btcReceiverAddress", btcReceiverAddress);
-    console.log("btcAmountInSatoshi", btcAmountInSatoshi);
-    console.log("txHash", txHash);
 
     if (!btcReceiverAddress || !btcAmountInSatoshi || !txHash) {
       console.log(
@@ -102,6 +97,9 @@ export async function GET(request: Request) {
       transaction,
       rsvSignatures,
     });
+
+    // gas settings is handled by signet.js
+    // can be manually set if needed
 
     const btcTxnHash = await bitcoin.broadcastTx(signedTransaction);
 


### PR DESCRIPTION
### Summary

This PR sets the gas setting for bitcoin PSBT.

### Changes made

- [x] Add max gas sats/vByte for a transaction. (ex. 10 sats/vB)

- [x] Test mainnet transaction.

### Related Issues

FIxes #42