### PR TITLE
Fix #110 : Init the NEAR protocol rewards tracking system 

### DIFF
--- a/.github/workflows/near-rewards.yml
+++ b/.github/workflows/near-rewards.yml
@@ -1,10 +1,10 @@
 name: NEAR Protocol Rewards Tracking
 on:
   schedule:
-    - cron: "0 0 * * *" # Every 24 hours at midnight
-  workflow_dispatch: # Manual trigger
+    - cron: '0 0 * * *'     # Every 24 hours at midnight
+  workflow_dispatch:        # Manual trigger
   push:
-    branches: [main] # Start on main branch updates
+    branches: [ main ]     # Start on main branch updates
 
 jobs:
   calculate-rewards:
@@ -18,14 +18,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
 
       - name: Calculate Rewards
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}
-          NEAR_ACCOUNT: 0xmht.near
-          NEAR_NETWORK_ID: mainnet
         run: |
           npm install -g near-protocol-rewards@latest
           near-protocol-rewards calculate


### PR DESCRIPTION
## Summary

This PR initializes the rewards tracking system for NEAR Protocol to start monitoring contributions and metrics for Cohort 2 by running `npx near-protocol-rewards init` 

## Changes made
- [x] Run `npx near-protocol-rewards init` .
- [x] Repo should have a `.yml` with correct configuration.

## Related Issues / PRs
Fixes #110 
