### PR TITLE
Fixes#120 :  Remove Dashboard Transaction History

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -27,7 +27,7 @@ import {
 import Image from "next/image";
 import { NearContext } from "@/context/context";
 import { connect, utils } from "near-api-js";
-import TransactionHistory from "@/components/dashboard/TransactionHistory";
+// import TransactionHistory from "@/components/dashboard/TransactionHistory";
 import { QRCodeCanvas } from "qrcode.react";
 import {
   Dialog,
@@ -388,7 +388,7 @@ export default function Dashboard() {
           </Card>
         </div>
 
-        <TransactionHistory btcPrice={bitcoinPrice} />
+        {/* <TransactionHistory btcPrice={bitcoinPrice} /> */}
       </main>
 
       {/* Footer */}


### PR DESCRIPTION
## Summary

This PR  temporarily comment out transaction history section of the dashboard in the UI until the API is restored.

## Changes made

- [x] Dashboard transaction history section is commented out or hidden in the UI.
- [x] No API calls to Blockscout are made while this section is disabled.

## Related Issues

Fixes #120 
