### PR TITLE
Fixes #116 : Add path for get-near-intents-deposit in ai-plugin 

### DIFF
--- a/src/app/api/ai-plugin/route.ts
+++ b/src/app/api/ai-plugin/route.ts
@@ -355,6 +355,85 @@ export async function GET() {
           },
         },
       },
+      "/api/tools/get-near-intents-deposit": {
+        get: {
+          operationId: "get-near-intents-deposit",
+          summary: "Get NEAR deposit intents",
+          description:
+            "Fetches NEAR deposit intents for the user, enabling deposit of assets from any wallet and swapping them into BTC via NEAR Intents.",
+          responses: {
+            "200": {
+              description: "Successful response",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      depositIntents: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            intentId: {
+                              type: "string",
+                              description: "Unique ID of the deposit intent",
+                            },
+                            asset: {
+                              type: "string",
+                              description: "Asset being deposited",
+                            },
+                            amount: {
+                              type: "string",
+                              description: "Amount of asset being deposited",
+                            },
+                            status: {
+                              type: "string",
+                              description:
+                                "Current status of the deposit intent",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Bad request",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: {
+                        type: "string",
+                        description: "Error message",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "500": {
+              description: "Server error",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: {
+                        type: "string",
+                        description: "Error message",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
   };
 


### PR DESCRIPTION
## Summary

This PR adds a new tool path `get-near-intents-deposit` in the AI Plugin to enable fetching NEAR deposit intents.

## Changes made

- [x] `get-near-intents-deposit` path is added to the AI Plugin with correct routing and response schema.
- [x] Path is tested and verified to return correct deposit intent data according to specification.

## Related Issues 

Fixes #116
