### PR TITLE
Fixes #115 : Create get-near-intents-deposit tool in api/tools

### DIFF
--- a/src/app/api/tools/get-near-intents-deposit/route.ts
+++ b/src/app/api/tools/get-near-intents-deposit/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    // Sample static response
+    return NextResponse.json({
+      message: "Sample response for get-near-intents-deposit",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Something went wrong" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the `get-near-intents-deposit` tool as a standalone tool under `api/tools`.

## Changes made

- [x] Create a new route for get-near-intents-deposit under under api/tools.
- [x] Add sample code for route.ts.

## Related Issues 

Fixes #115 
