### PR TITLE
Fixes #128: add check-supported-token and swap-to-bitcoin tool descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,9 @@ Now, you can send transactions on the Bitcoin mainnet using just your NEAR accou
 
   - `send-btc-txn` : Broadcast a signed transaction to Bitcoin mainnet
 
-  - `get-near-intents-deposit` : Retrieve NEAR intents deposit address for an asset for a connected user.
+  - `check-supported-token` : Checks if asset is supported for swap to BTC through NEAR intents on NEAR blockchain.
 
-  - `swap-to-bitcoin` : Swap any deposited asset to bitcoin using NEAR intents.
-
-  - `withdraw-bitcoin` : Withdraw Bitcoin to an external wallet or your MPC wallet.
+  - `swap-to-bitcoin` : Swap any deposited asset to bitcoin using NEAR intents and withdraw to your MPC bitcoin wallet.
 
 - Each tool is registered in the AI plugin manifest at : `/api/ai-plugin`
 


### PR DESCRIPTION
## Summary

Enhances NEAR intents integration by adding asset support checks and enabling swaps from any deposited asset to BTC with withdrawal to the MPC Bitcoin wallet.

## Changes made

- [x] Add check-supported-token to check if asset is supported for swap to BTC through NEAR intents on NEAR blockchain.
- [x] Update swap-to-bitcoin that allows users to swap any deposited asset to bitcoin using NEAR intents and withdraw to your MPC bitcoin wallet.

## Related Issues / PRs

Fixes #128 


