### PR TITLE
Fixes #142 : update api call for check-supported-token-tool

### DIFF
--- a/src/app/api/ai-plugin/route.ts
+++ b/src/app/api/ai-plugin/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
     },
     servers: [
       {
-        url: "https://bitcoin-agent.xyz",
+        url: process.env.NODE_ENV === 'development' ? "http://localhost:3000" : "https://bitcoin-agent.xyz",
       },
     ],
     "x-mb": {
@@ -359,13 +359,23 @@ export async function GET() {
           },
         },
       },
-      // TO DO
       "/api/tools/check-supported-token": {
         get: {
           operationId: "check-supported-token",
           summary: "Check supported token for swap to BTC on NEAR",
           description:
             "Checks if asset is supported for swap to BTC through NEAR intents on NEAR blockchain.",
+          parameters: [
+            {
+              name: "assetName",
+              in: "query",
+              required: true,
+              schema: {
+                type: "string",
+              },
+              description: "The name or symbol of the asset to check",
+            },
+          ],
           responses: {
             "200": {
               description: "Successful response",
@@ -374,30 +384,13 @@ export async function GET() {
                   schema: {
                     type: "object",
                     properties: {
-                      depositIntents: {
-                        type: "array",
-                        items: {
-                          type: "object",
-                          properties: {
-                            intentId: {
-                              type: "string",
-                              description: "Unique ID of the deposit intent",
-                            },
-                            asset: {
-                              type: "string",
-                              description: "Asset being deposited",
-                            },
-                            amount: {
-                              type: "string",
-                              description: "Amount of asset being deposited",
-                            },
-                            status: {
-                              type: "string",
-                              description:
-                                "Current status of the deposit intent",
-                            },
-                          },
-                        },
+                      assetAvailableForSwap: {
+                        type: "boolean",
+                        description: "Whether the asset is available for swapping",
+                      },
+                      OnBlockchain: {
+                        type: "string",
+                        description: "The blockchain where the asset exists",
                       },
                     },
                   },


### PR DESCRIPTION
## Summary

This PR modify the `ai-plugin` call to use the newly implemented `check-supported-token` tool for retrieving and validating supported tokens from the NEAR Intents 1Click API. This ensures token support checks are consistent across the system.

## Changes made

- [x] `ai-plugin` uses the `check-supported-token` tool instead of any hardcoded or outdated API calls for token validation.
- [x] The updated integration correctly returns validation results based on the latest supported token list from the NEAR Intents 1Click API.

## Related Issues / PRs

Fixes #142 
