### PR TITLE
Fixes #154 : Add technical roadmap 

### DIFF
--- a/docs/technical-roadmap.md
+++ b/docs/technical-roadmap.md
@@ -38,3 +38,42 @@ Transform Bitcoin Agent into a **full-featured trading agent** capable of buy, s
   - End-to-end demo where a NEAR AI trading agent triggers Bitcoin Agent to execute a BTC transaction or trade.
 
 ---
+
+## Q3 – Axons Network: MCP Infrastructure & Multichain Wallets ⚡
+
+### Objective
+
+Evolve Bitcoin Agent into the **first participant of Axons Network** — a multi-network MCP infrastructure on NEAR, supporting **multi-chain wallets with unified liquidity** and **instant swaps**. Axons Network will serve as the **infrastructure backbone** that allows agents across chains to interoperate seamlessly.
+
+### Milestones & Deliverables
+
+1. **Axons MCP Servers for Agents on NEAR**
+
+   - Build **Axons Network MCP servers** that standardize how agents operate on NEAR.
+   - Each MCP server will handle requests, signature flows, and execution for its corresponding chain/agent.
+   - Deliverables:
+     - Axons MCP server template for agents (starting with Bitcoin Agent).
+     - Interfaces for secure communication between Axons MCP servers and NEAR chain signatures.
+     - Proof-of-concept Axons MCP deployment with Bitcoin Agent as first adopter.
+
+2. **Multichain Wallets with Unified Liquidity**
+
+   - Extend Bitcoin Agent into a **multi-chain wallet abstraction**, allowing users to manage BTC alongside NEAR-native assets.
+   - Aggregate liquidity from multiple Axons MCP servers so users can access **unified liquidity pools** across chains.
+   - Deliverables:
+     - Unified wallet interface abstracting NEAR + BTC.
+     - Cross-agent liquidity pooling mechanism.
+     - Testnet flow: Swap BTC → USDC.near → ETH (simulated multichain trade).
+
+3. **Instant Swaps Powered by NEAR Intents**
+   - Enable **low-latency swaps across assets and chains** by combining unified liquidity + intents.
+   - Optimize the flow so swaps feel near-instant, while still remaining fully on-chain and verifiable.
+   - Deliverables:
+     - Intent router for multi-chain swaps.
+     - Integration with NEAR chain signatures for MPC wallet support.
+     - Benchmarked demo of cross-chain instant swaps with settlement proofs.
+
+---
+
+✅ By the end of **Q2**, Bitcoin Agent will evolve into a **trade-ready, AI-integrated execution agent** for BTC on NEAR.  
+✅ By the end of **Q3**, Bitcoin Agent will pioneer **Axons Network**, enabling multi-chain wallets, unified liquidity, and instant cross-chain swaps — establishing the foundation for a **network of multi-chain agents on NEAR**.


### PR DESCRIPTION
## Summary

This PR add a `technical-roadmap.md` file in `/docs` detailing Q2 and Q3 technical milestones for Bitcoin Agent.

## Changes made

- [x] `technical-roadmap.md` is added to `/docs`.
- [x] Roadmap includes Q2 (trading + NEAR AI) and Q3 (Axons Network infra).

## Related Issues / PRs

Fixes #154 
