### PR TITLE
Fixes #214: Add Docs Reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [🔧 Setup](#setup)
 - [📊 Usage](#usage)
 - [🛠️ Agent Tools](#agent-tools)
+- [📚 Docs](#docs)
 - [🌐 Links](#links)
 - [🤝 Contributing](#contributing)
 - [📄 License](#license)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,18 @@ The Bitcoin Agent provides several powerful tools built using the [Bitte.ai Agen
 
 All tools are registered in the AI plugin manifest at `/api/ai-plugin`.
 
+## 📚 Docs
+
+The `/docs` folder contains detailed documentation to support the Bitcoin Agent project.
+It includes:
+
+- Lean Canvas & Competitive Analysis
+- Technical Roadmap & Architecture
+- Risk Register
+- Tech Stack
+- Initial Reviews & Feedback
+- Progress Summaries
+
 ## Links
 
 - 🌍 **Website**: [bitcoin-agent.xyz](https://bitcoin-agent.xyz)

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ It includes:
 - Initial Reviews & Feedback
 - Progress Summaries
 
+You can explore the full set of documents here: [📂 View Docs Folder](/docs)
+
 ## Links
 
 - 🌍 **Website**: [bitcoin-agent.xyz](https://bitcoin-agent.xyz)


### PR DESCRIPTION
## Summary

This PR adds docs section in the Table of Contents and add a reference to the `/docs` folder. 

## Changes made

- [x] Table of Contents includes a **Docs** section linking to the /docs folder.
- [x] A short **Docs** section is added in the README body with references to key documents.

## Related Issues / PRs

Fixes #214 
