### PR TITLE
Fixes #220 : Link Docs to its content in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The Bitcoin Agent provides several powerful tools built using the [Bitte.ai Agen
 
 All tools are registered in the AI plugin manifest at `/api/ai-plugin`.
 
-## 📚 Docs
+## Docs
 
 The `/docs` folder contains detailed documentation to support the Bitcoin Agent project.
 It includes:


### PR DESCRIPTION
## Summary

This PR links the docs section to its content.

## Changes made

- [x] Docs should be correctly mapped to its content.

## Related Issues / PRs

List any relevant issues or pull requests

Fixes #220 
